### PR TITLE
Add BitReader.Reset(io.Reader) and BitWriter.Reset(io.Writer)

### DIFF
--- a/bitstream.go
+++ b/bitstream.go
@@ -197,3 +197,21 @@ func (b *BitWriter) WriteBits(u uint64, nbits int) error {
 
 	return nil
 }
+
+// Reset replaces the underlying io.Reader with the provided reader and resets
+// all interal state to its zero value, allowing for reuse of the BitReader
+// without additional allocations
+func (b *BitReader) Reset(r io.Reader) {
+	b.r = r
+	b.b[0] = 0x00
+	b.count = 0
+}
+
+// Reset replaces the underlying io.Writer with the provided writer and resets
+// all internal state to its initial value allowing for reuse of the BitWriter
+// without additional allocations
+func (b *BitWriter) Reset(w io.Writer) {
+	b.w = w
+	b.b[0] = 0x00
+	b.count = 8
+}

--- a/bitstream_test.go
+++ b/bitstream_test.go
@@ -206,3 +206,34 @@ func TestErrorPropagation(t *testing.T) {
 		t.Errorf("failed to propagate error")
 	}
 }
+
+func TestReset(t *testing.T) {
+	r := NewReader(strings.NewReader("abc"))
+	b, _ := r.ReadBits(8)
+	if b != 'a' {
+		t.Errorf("expected 'a', got=%08b", b)
+	}
+
+	r.Reset(strings.NewReader("def"))
+	b, _ = r.ReadBits(8)
+
+	if b != 'd' {
+		t.Errorf("expected 'd', got=%08b", b)
+	}
+
+	firstWriter := bytes.NewBuffer(nil)
+	w := NewWriter(firstWriter)
+	w.WriteBits(97, 8)
+
+	secondWriter := bytes.NewBuffer(nil)
+	w.Reset(secondWriter)
+	w.WriteBits(98, 8)
+
+	if firstWriter.String() != "a" {
+		t.Errorf("expected 'a', got=%x", firstWriter.Bytes())
+	}
+
+	if secondWriter.String() != "b" {
+		t.Errorf("expected 'b', got=%x", secondWriter.Bytes())
+	}
+}


### PR DESCRIPTION
To support reusing a Bit{Reader,Writer} without requiring additional allocations