### PR TITLE
Explicitly declare One as type Bit instead of bool

### DIFF
--- a/bitstream.go
+++ b/bitstream.go
@@ -12,7 +12,7 @@ const (
 	// Zero is our exported type for '0' bits
 	Zero Bit = false
 	// One is our exported type for '1' bits
-	One = true
+	One Bit = true
 )
 
 // A BitReader reads bits from an io.Reader


### PR DESCRIPTION
Without this, One is just an untyped bool.

https://play.golang.org/p/6Yahc7dTSBx