### PR TITLE
Add BitReader.Align() 

### DIFF
--- a/bitstream.go
+++ b/bitstream.go
@@ -164,6 +164,11 @@ func (b *BitReader) ReadBits(nbits int) (uint64, error) {
 	return u, nil
 }
 
+// Align the reader to the next byte boundary.
+func (b *BitReader) Align() {
+	b.count = 0
+}
+
 // Flush empties the currently in-process byte by filling it with 'bit'.
 func (b *BitWriter) Flush(bit Bit) error {
 

--- a/bitstream_test.go
+++ b/bitstream_test.go
@@ -237,3 +237,16 @@ func TestReset(t *testing.T) {
 		t.Errorf("expected 'b', got=%x", secondWriter.Bytes())
 	}
 }
+
+func TestAlign(t *testing.T) {
+	r := NewReader(bytes.NewBuffer([]byte{0xf0, 0xf0}))
+	b, _ := r.ReadBits(4)
+	if b != 0xf {
+		t.Errorf("expected '0xf', got=%08b", b)
+	}
+	r.Align()
+	b, _ = r.ReadBits(4)
+	if b != 0xf {
+		t.Errorf("expected '0xf', got=%08b", b)
+	}
+}


### PR DESCRIPTION
Adds a method to BitReader to align a stream to the next byte boundary.

This is often a useful method as many bit-stream based formats expect data to start at a boundary after a number of arbitrary bits. For instance, a golomb encoded value may precede a structure that is byte aligned.